### PR TITLE
Treat errors returned by UnmarshalYAML as type errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -363,14 +363,20 @@ func (d *decoder) terror(n *Node, tag string, out reflect.Value) {
 
 func (d *decoder) callUnmarshaler(n *Node, u Unmarshaler) (good bool) {
 	err := u.UnmarshalYAML(n)
-	if e, ok := err.(*TypeError); ok {
+	switch e := err.(type) {
+	case nil:
+		return true
+	case *TypeError:
 		d.terrors = append(d.terrors, e.Errors...)
 		return false
+	default:
+		d.terrors = append(d.terrors, UnmarshalError{
+			Message: err.Error(),
+			Line:    n.Line,
+			Column:  n.Column,
+		})
+		return false
 	}
-	if err != nil {
-		fail(err)
-	}
-	return true
 }
 
 func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good bool) {
@@ -385,14 +391,20 @@ func (d *decoder) callObsoleteUnmarshaler(n *Node, u obsoleteUnmarshaler) (good 
 		}
 		return nil
 	})
-	if e, ok := err.(*TypeError); ok {
+	switch e := err.(type) {
+	case nil:
+		return true
+	case *TypeError:
 		d.terrors = append(d.terrors, e.Errors...)
 		return false
+	default:
+		d.terrors = append(d.terrors, UnmarshalError{
+			Message: err.Error(),
+			Line:    n.Line,
+			Column:  n.Column,
+		})
+		return false
 	}
-	if err != nil {
-		fail(err)
-	}
-	return true
 }
 
 // d.prepare initializes and dereferences pointers and calls UnmarshalYAML

--- a/decode_test.go
+++ b/decode_test.go
@@ -1272,8 +1272,22 @@ func (ft *failingUnmarshaler) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (s *S) TestUnmarshalerError(c *C) {
-	err := yaml.Unmarshal([]byte("a: b"), &failingUnmarshaler{})
-	c.Assert(err, Equals, failingErr)
+	data := `{foo: 123, bar: {}, spam: "test"}`
+	dst := struct {
+		Foo  int
+		Bar  *failingUnmarshaler
+		Spam string
+	}{}
+	err := yaml.Unmarshal([]byte(data), &dst)
+	c.Assert(err, DeepEquals, &yaml.TypeError{
+		Errors: []yaml.UnmarshalError{
+			{Line: 1, Column: 17, Message: failingErr.Error()},
+		},
+	})
+	// whatever could be unmarshaled must be unmarshaled
+	c.Assert(dst.Foo, Equals, 123)
+	c.Assert(dst.Bar, Equals, &failingUnmarshaler{})
+	c.Assert(dst.Spam, Equals, "test")
 }
 
 type obsoleteFailingUnmarshaler struct{}
@@ -1283,8 +1297,22 @@ func (ft *obsoleteFailingUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) 
 }
 
 func (s *S) TestObsoleteUnmarshalerError(c *C) {
-	err := yaml.Unmarshal([]byte("a: b"), &obsoleteFailingUnmarshaler{})
-	c.Assert(err, Equals, failingErr)
+	data := `{foo: 123, bar: {}, spam: "test"}`
+	dst := struct {
+		Foo  int
+		Bar  *obsoleteFailingUnmarshaler
+		Spam string
+	}{}
+	err := yaml.Unmarshal([]byte(data), &dst)
+	c.Assert(err, DeepEquals, &yaml.TypeError{
+		Errors: []yaml.UnmarshalError{
+			{Line: 1, Column: 17, Message: failingErr.Error()},
+		},
+	})
+	// whatever could be unmarshaled must be unmarshaled
+	c.Assert(dst.Foo, Equals, 123)
+	c.Assert(dst.Bar, Equals, &obsoleteFailingUnmarshaler{})
+	c.Assert(dst.Spam, Equals, "test")
 }
 
 type sliceUnmarshaler []int


### PR DESCRIPTION
So they don't fail the unmarshaling immediately, and record the failure location.